### PR TITLE
Add 'fallback' parameter to 'integer' function.

### DIFF
--- a/jscheck.js
+++ b/jscheck.js
@@ -48,13 +48,13 @@ var JSC = (function () {
                 ? value.apply(null, slice.call(arguments, 1))
                 : value;
         },
-        integer = function (value) {
+        integer = function (value, fallback) {
             value = resolve(value);
             return typeof value === 'number'
                 ? Math.floor(value)
                 : typeof value === 'string'
                 ? value.charCodeAt(0)
-                : undefined;
+                : fallback;
         },
         go = function (func, value) {
 
@@ -510,7 +510,7 @@ var JSC = (function () {
                         return integer_prime;
                     };
                 }
-                i = integer(i, 0) || 0;
+                i = integer(i, 0);
                 j = integer(j, 0);
                 if (j === undefined) {
                     j = i;


### PR DESCRIPTION
When 'value' is not number or string then fallback is used.
Thanks to that instead of:

integer(inputValue) || 0

we can write:

integer(inputValue, 0)
