### PR TITLE
Fix TypeError

### DIFF
--- a/jscheck.js
+++ b/jscheck.js
@@ -574,9 +574,8 @@ var JSC = (function () {
                         values = resolve(value);
                         if (Array.isArray(keys)) {
                             keys.forEach(function (key, i) {
-                                i = i % values.length;
                                 result[key] = resolve((Array.isArray(values)
-                                    ? values[i]
+                                    ? values[i % values.length]
                                     : value), i);
                             });
                             return result;


### PR DESCRIPTION
TypeError is throw when as second parameter to 'object' method we pass sth like this:

function () { return null; }

or 

function (i) { return i; } // generating sequence of numbers for object's properties

because 'length' property is read from value returned by:

resolve(value);

which is null/undefined in our case.
