### PR TITLE
Allow use from node.js

### DIFF
--- a/jscheck.js
+++ b/jscheck.js
@@ -19,7 +19,7 @@
 */
 
 
-var JSC = (function () {
+(function (global) {
     'use strict';
 
     var all,            // The collection of all claims
@@ -752,5 +752,5 @@ var JSC = (function () {
         jsc.falsy(), jsc.integer(), jsc.number(),
         jsc.string(), true, Infinity, -Infinity
     ];
-    return jsc.clear();
-}());
+    global.JSC = jsc.clear();
+}(this));


### PR DESCRIPTION
With just a minor tweak, we should be able to use this both in Node.js and the browsers.

Commonjs allows us to export the namespace this way, without having to call `module.exports`.
